### PR TITLE
freeplay colors for thorns, monster and winter horrorland

### DIFF
--- a/assets/preload/weeks/week2.json
+++ b/assets/preload/weeks/week2.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Spookeez", "spooky", [34, 51, 68]],
 		["South", "spooky", [34, 51, 68]],
-		["Monster", "monster", [34, 51, 68]]
+		["Monster", "monster", [120, 122, 35]]
 	],
 
 	"weekCharacters": [

--- a/assets/preload/weeks/week5.json
+++ b/assets/preload/weeks/week5.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Cocoa", "parents", [160, 209, 255]],
 		["Eggnog", "parents", [160, 209, 255]],
-		["Winter Horrorland", "monster", [160, 209, 255]]
+		["Winter Horrorland", "monster", [120, 122, 35]]
 	],
 
 	"weekCharacters": [

--- a/assets/preload/weeks/week6.json
+++ b/assets/preload/weeks/week6.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Senpai", "senpai-pixel", [255, 120, 191]],
 		["Roses", "senpai-pixel", [255, 120, 191]],
-		["Thorns", "spirit-pixel", [255, 120, 191]]
+		["Thorns", "spirit-pixel", [153, 17, 44]]
 	],
 
 	"weekCharacters": [


### PR DESCRIPTION
well, yknow that Monster and Spirit has different icons from the others characters at the same week, right? So, it will fix something (small thing, like #386)

SCREENSHOTS BELOW:
![image](https://user-images.githubusercontent.com/72695242/143770810-d751d5b9-cc5d-44c5-8645-28614f09a8e7.png)
![image](https://user-images.githubusercontent.com/72695242/143770817-eca1462d-978a-40b0-95b7-192e89671575.png)
![image](https://user-images.githubusercontent.com/72695242/143770822-62f6a80d-311c-4b2c-a9f0-29b336a6d500.png)